### PR TITLE
Use of 'const' causes SyntaxError

### DIFF
--- a/lib/http-digest.js
+++ b/lib/http-digest.js
@@ -3,8 +3,8 @@ var http = require('http');
 var crypto = require('crypto');
 
 /* constants */
-const nonce_expire_timeout = 3600000;            /* server nonce expiration timeout (milliseconds) */
-const authentication_realm = "node-http-digest"; /* http authentication realm */
+var nonce_expire_timeout = 3600000;            /* server nonce expiration timeout (milliseconds) */
+var authentication_realm = "node-http-digest"; /* http authentication realm */
 
 /* state information */
 var nonces = {};
@@ -100,7 +100,7 @@ function authenticate(request, header, username, password) {
 	if (!(authinfo.nonce in nonces)) {
 		return false;
 	}
-	
+
 	// calculate a1
 	var a1;
 	if (authinfo.algorithm == "MD5-sess") {
@@ -144,9 +144,9 @@ function authenticate(request, header, username, password) {
 }
 
 /**
- * The http_digest_auth function authenticates the current http request and 
- * executes the callback if the user is authenticated successfully. Otherwise 
- * a 401 Unauthorized page is presented. 
+ * The http_digest_auth function authenticates the current http request and
+ * executes the callback if the user is authenticated successfully. Otherwise
+ * a 401 Unauthorized page is presented.
  * The callback is of type function(request, response).
  */
 var http_digest_auth = exports.http_digest_auth = function(request, response, username, password, callback) {
@@ -177,7 +177,7 @@ var http_digest_auth = exports.http_digest_auth = function(request, response, us
 }
 
 /**
- * The createServer method creates a web server using HTTP Digest 
+ * The createServer method creates a web server using HTTP Digest
  * authentication. Usage of this function is similar to the http.createServer
  * function of the node.js standard library, but with additional parameters for
  * the username and password.


### PR DESCRIPTION
'const' is not a valid strict mode keyword. Using this with node v0.4 causes a SyntaxError.
